### PR TITLE
feat(server): implement login service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,7 +1408,6 @@ dependencies = [
 name = "server"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "axum",
  "log",
  "oauth",

--- a/backend/server/Cargo.toml
+++ b/backend/server/Cargo.toml
@@ -4,7 +4,6 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-anyhow.workspace = true
 log.workspace = true
 oauth.workspace = true
 redis.workspace = true

--- a/backend/server/src/error.rs
+++ b/backend/server/src/error.rs
@@ -1,0 +1,20 @@
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+
+pub(crate) struct AppError {
+    pub(crate) status: StatusCode,
+    pub(crate) message: Option<String>,
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        (
+            self.status,
+            self.message
+                .unwrap_or_else(|| self.status.canonical_reason().unwrap_or("").to_string()),
+        )
+            .into_response()
+    }
+}
+
+pub(crate) type ResponseResult<T> = std::result::Result<T, AppError>;

--- a/backend/server/src/main.rs
+++ b/backend/server/src/main.rs
@@ -1,3 +1,50 @@
-fn main() {
-    println!("Hello, world!");
+mod error;
+mod routes;
+
+use crate::routes::login::{get_login_url, login};
+use axum::http::StatusCode;
+use axum::routing::get;
+use axum::Router;
+use oauth::DiscordOAuth;
+use redis::Client;
+use std::env;
+use tokio::net::TcpListener;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    let redis = Client::open(env::var("REDIS_URL").expect("REDIS_URL not set"))
+        .expect("Failed to connect to Redis");
+
+    let state = AppState {
+        oauth: DiscordOAuth::new(
+            env::var("DISCORD_CLIENT_ID").expect("DISCORD_CLIENT_ID not set"),
+            env::var("DISCORD_CLIENT_SECRET").expect("DISCORD_CLIENT_SECRET not set"),
+            format!(
+                "{}/login",
+                env::var("DISCORD_REDIRECT_URI").expect("DISCORD_REDIRECT_URI not set")
+            ),
+            redis,
+        ),
+    };
+
+    log::info!("Server starting");
+
+    let listener = TcpListener::bind("0.0.0.0:8080").await.unwrap();
+    let router = Router::new().route("/login", get(get_login_url).post(login));
+    axum::serve(
+        listener,
+        Router::new()
+            .nest("/api", router)
+            .fallback(|| async { StatusCode::NOT_FOUND })
+            .with_state(state),
+    )
+    .await
+    .unwrap();
+}
+
+#[derive(Clone, Debug)]
+struct AppState {
+    oauth: DiscordOAuth,
 }

--- a/backend/server/src/routes/login.rs
+++ b/backend/server/src/routes/login.rs
@@ -1,0 +1,65 @@
+use crate::error::{AppError, ResponseResult};
+use crate::AppState;
+use axum::extract::State;
+use axum::http::StatusCode;
+use oauth::User;
+use serde::{Deserialize, Serialize};
+
+pub(crate) async fn get_login_url(
+    State(state): State<AppState>,
+) -> ResponseResult<axum::response::Json<RedirectResponse>> {
+    Ok(axum::response::Json(RedirectResponse {
+        url: state
+            .oauth
+            .generate_authorization_url()
+            .await
+            .map_err(|_| AppError {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                message: None,
+            })?
+            .to_string(),
+    }))
+}
+
+pub(crate) async fn login(
+    State(state): State<AppState>,
+    axum::extract::Json(data): axum::extract::Json<LoginRequest>,
+) -> ResponseResult<axum::response::Json<User>> {
+    match state.oauth.get_user(data.code, data.state).await {
+        Ok(user) => Ok(axum::response::Json(user)),
+
+        Err(e) => match e {
+            oauth::error::Error::InvalidState { state: _ } => Err(AppError {
+                status: StatusCode::UNAUTHORIZED,
+                message: None,
+            }),
+            oauth::error::Error::NotMember => Err(AppError {
+                status: StatusCode::FORBIDDEN,
+                message: None,
+            }),
+            oauth::error::Error::RedisConnectionLost => Err(AppError {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                message: None,
+            }),
+            oauth::error::Error::Unknown(e) => {
+                log::error!("Unknown error: {}", e);
+
+                Err(AppError {
+                    status: StatusCode::INTERNAL_SERVER_ERROR,
+                    message: None,
+                })
+            }
+        },
+    }
+}
+
+#[derive(Serialize, Debug)]
+pub(crate) struct RedirectResponse {
+    url: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct LoginRequest {
+    code: String,
+    state: String,
+}

--- a/backend/server/src/routes/mod.rs
+++ b/backend/server/src/routes/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod login;


### PR DESCRIPTION
`DISCORD_CLIENT_ID` `DISCORD_CLIENT_SECRET` `DISCORD_REDIRECT_URI` を設定して、サーバーを起動すること

`DISCORD_REDIRECT_URI` は `http://localhost:8080`

ログインエンドポイントは:

1. `GET /login`

Response Body:
```json
{
 "url": "login URL"
}
```

3. `POST /login`

Body:
```json
{
 "code": "String",
 "state": "String"
}
```

Response Body:
```json
{
 "id": "Snowflake",
 "name": "String",
 "avatar": "URL Format"
}
```

OpenAPI format の yaml を用意する？

