### PR TITLE
chore(front): fix tailwind config

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config = {
-  content: ["./src/**/*.tsx"],
+  content: ["./frontend/**/*.tsx"],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
Tailwind CSS の対象ファイルが `src/` だったため、`frontend/` に修正